### PR TITLE
Disable spin button when list empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
 
         const div=document.createElement('div');div.className='menu-item';div.textContent=name;div.onclick=()=>removeItem(i);menuList.appendChild(div);
       });
+      setBtn(items.length>0);
     }
 
     /* ---------- Firework ---------- */
@@ -126,11 +127,12 @@
 
     /* ---------- Events ---------- */
     addBtn.addEventListener('click',addItem);
+    input.addEventListener('keydown',e=>{if(e.key==='Enter')addItem();});
     spinBtn.addEventListener('click',spin);
     canvas.addEventListener('click',e=>{if(isSpinning||!items.length)return;const rect=canvas.getBoundingClientRect(),x=e.clientX-rect.left-canvas.width/2,y=e.clientY-rect.top-canvas.height/2;if(Math.hypot(x,y)>canvas.width/2)return;const deg=((Math.atan2(y,x)*180/Math.PI)+450)%360;removeItem(Math.floor(deg/(360/items.length)));});
 
     /* ---------- Init ---------- */
-    resizeCanvas(); setBtn(true);
+    resizeCanvas(); setBtn(items.length>0); input.focus();
   });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Disable spin button when no participants are added
- Allow adding participants via Enter key and auto-focus input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916d8582a08322b9fbda16e8dba6c1