### PR TITLE
fix: register service worker and correct cache list

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,13 @@
     /* ---------- Init ---------- */
     resizeCanvas(); setBtn(true);
   });
+
+  // Register the service worker for offline support when available
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('sw.js');
+    });
+  }
   </script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -5,8 +5,10 @@ const FILES_TO_CACHE = [
   "./icon.png",
   "./og_icon.png",
   "./manifest.json",
-  "./main.js"
 ];
+
+// Removed "./main.js" from the cache list as the file does not exist.
+// Attempting to cache a missing file caused the service worker installation to fail.
 
 self.addEventListener("install", (event) => {
   event.waitUntil(


### PR DESCRIPTION
## Summary
- remove reference to nonexistent `main.js` from service worker cache to prevent installation failures
- register `sw.js` from `index.html` so the PWA can work offline

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916d6d411c8322979d01d33b4c19b4